### PR TITLE
OpenShift 4.7

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -47,7 +47,7 @@ toc::[]
 === Tested Configurations
 
 * Pop!OS 20.04 LTS
-* OpenShift 4.5.14
+* OpenShift 4.5.14, 4.7.6
 * Terraform v0.12
 
 

--- a/ansible/playbooks/templates/haproxy/haproxy.cfg
+++ b/ansible/playbooks/templates/haproxy/haproxy.cfg
@@ -43,6 +43,12 @@ defaults
     maxconn                 3000
 
 #-----
+# DNS resolver querying
+#-----
+resolvers cluster-dns
+    nameserver dns1 192.168.200.1:53
+
+#-----
 # HAProxy status front end
 #-----
 frontend stats
@@ -67,7 +73,7 @@ frontend openshift-api-server
 backend openshift-api-server
     balance source
     mode tcp
-    server {{ bootstrap.hostname }} {{ bootstrap.fqdn }}:6443 check
+    server-template {{ bootstrap.hostname }} 1 {{ bootstrap.fqdn }}:6443 check resolvers cluster-dns init-addr none
 {% for host in masters %}
     server {{ host.hostname }} {{ host.fqdn }}:6443 check
 {% endfor %}
@@ -87,7 +93,7 @@ frontend machine-config-server
 backend machine-config-server
     balance source
     mode tcp
-    server {{ bootstrap.hostname }} {{ bootstrap.fqdn }}:22623 check
+    server-template {{ bootstrap.hostname }} 1 {{ bootstrap.fqdn }}:22623 check resolvers cluster-dns init-addr none
 {% for host in masters %}
     server {{ host.hostname }} {{ host.fqdn }}:22623 check
 {% endfor %}

--- a/main.tf
+++ b/main.tf
@@ -58,7 +58,7 @@ module "boostrap-node" {
     hosts_info = [ module.machines-info.hosts_config.bootstrap ]
     ignition_config_path = module.install-config.bootstrap_ignition
     image_dir = "/var/lib/libvirt/images"
-    image_name = "rhcos-4.5.2-x86_64-qemu.x86_64.qcow2"
+    image_name = "rhcos-4.7.0-x86_64-qemu.x86_64.qcow2"
     network_name = var.cluster_network_name
     cpu = var.bootstrap_cpu
     memory = var.bootstrap_memory
@@ -72,7 +72,7 @@ module "control-nodes" {
     hosts_info = module.machines-info.hosts_config.masters
     ignition_config_path = module.install-config.master_ignition
     image_dir = "/var/lib/libvirt/images"
-    image_name = "rhcos-4.5.2-x86_64-qemu.x86_64.qcow2"
+    image_name = "rhcos-4.7.0-x86_64-qemu.x86_64.qcow2"
     network_name = var.cluster_network_name
     cpu = var.master_cpu
     memory = var.master_memory
@@ -86,7 +86,7 @@ module "compute-nodes" {
     hosts_info = module.machines-info.hosts_config.workers
     ignition_config_path = module.install-config.compute_ignition
     image_dir = "/var/lib/libvirt/images"
-    image_name = "rhcos-4.5.2-x86_64-qemu.x86_64.qcow2"
+    image_name = "rhcos-4.7.0-x86_64-qemu.x86_64.qcow2"
     network_name = var.cluster_network_name
     cpu = var.worker_cpu
     memory = var.worker_memory
@@ -100,7 +100,7 @@ module "compute-nodes" {
 #    hosts_info = module.machines-info.hosts_config.infras
 #    ignition_config_path = module.install-config.compute_ignition
 #    image_dir = "/var/lib/libvirt/images"
-#    image_name = "rhcos-4.5.2-x86_64-qemu.x86_64.qcow2"
+#    image_name = "rhcos-4.7.0-x86_64-qemu.x86_64.qcow2"
 #    network_name = var.cluster_network_name
 #    cpu = var.infra_cpu
 #    memory = var.infra_memory

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -1,6 +1,6 @@
 # TODO These values should only be examples
 
-openshift_installer = "../assets/openshift-install"
+openshift_installer = "../assets/openshift-install-4.7.6"
 pull_secret_file    = "../assets/pull-secret.txt"
 
 cluster_name = "ocp"


### PR DESCRIPTION
Migrated to using DNS Discovery with HAProxy for bootstrap node health check
Updated variables to use RHCOS 4.7.0 image.
Updated variables to use OpenShift 4.7.6 intaller.